### PR TITLE
feature: support option for always emitting at least one (empty) buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Create a new through stream `b` that outputs chunks of length `size` or
 
 When `opts.zeroPadding` is false, do not zero-pad the last chunk.
 
+When `opts.emitEmpty` is true (default is `false`), emit a zero-sized buffer when the source is empty or only feeds in zero-length buffers.
+
 # License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -42,12 +42,9 @@ module.exports = function block (size, opts) {
         var zeroes = new Buffer(size - bufferedBytes)
         zeroes.fill(0)
         buffered.push(zeroes)
-        this.queue(Buffer.concat(buffered))
-        buffered = null
-      } else {
-        this.queue(Buffer.concat(buffered))
-        buffered = null
       }
+      this.queue(Buffer.concat(buffered))
+      buffered = null
     }
     this.queue(null)
   })

--- a/test/empty.js
+++ b/test/empty.js
@@ -1,0 +1,127 @@
+'use strict'
+
+var test = require('tape')
+
+var pull = require('pull-stream')
+
+var block = require('../')
+
+test('does not emit on empty buffers', function (t) {
+  t.plan(2)
+
+  pull(
+    pull.values([
+      new Buffer([]),
+      new Buffer([]),
+      new Buffer([])
+    ]),
+    block(),
+    pull.collect(function (err, buffers) {
+      t.error(err)
+      t.equal(buffers.length, 0)
+    })
+  )
+})
+
+test('respects noEmpty option and nopad on empty stream', function (t) {
+  t.plan(3)
+
+  pull(
+    pull.empty(),
+    block({ emitEmpty: true, nopad: true }),
+    pull.collect(function (err, buffers) {
+      t.error(err)
+      t.equal(buffers.length, 1)
+      t.equal(buffers[0].length, 0)
+    })
+  )
+})
+
+test('respects noEmpty option and nopad on empty buffers', function (t) {
+  t.plan(3)
+
+  pull(
+    pull.values([
+      new Buffer([]),
+      new Buffer([]),
+      new Buffer([])
+    ]),
+    block({ emitEmpty: true, nopad: true }),
+    pull.collect(function (err, buffers) {
+      t.error(err)
+      t.equal(buffers.length, 1)
+      t.equal(buffers[0].length, 0)
+    })
+  )
+})
+
+test('respects noEmpty option on empty stream', function (t) {
+  t.plan(4)
+
+  pull(
+    pull.empty(),
+    block({ emitEmpty: true }),
+    pull.collect(function (err, buffers) {
+      t.error(err)
+      t.equal(buffers.length, 1)
+      t.equal(buffers[0].length, 512)
+      t.deepEqual(buffers[0], Buffer.alloc(512))
+    })
+  )
+})
+
+test('respects noEmpty option on empty buffers', function (t) {
+  t.plan(4)
+
+  pull(
+    pull.values([
+      new Buffer([]),
+      new Buffer([]),
+      new Buffer([])
+    ]),
+    block({ emitEmpty: true }),
+    pull.collect(function (err, buffers) {
+      t.error(err)
+      t.equal(buffers.length, 1)
+      t.equal(buffers[0].length, 512)
+      t.deepEqual(buffers[0], Buffer.alloc(512))
+    })
+  )
+})
+
+test('does not emit extra buffer if noEmpty and nopad is present', function (t) {
+  t.plan(3)
+
+  pull(
+    pull.values([
+      new Buffer([]),
+      new Buffer('hey'),
+      new Buffer([])
+    ]),
+    block({ emitEmpty: true, nopad: true }),
+    pull.collect(function (err, buffers) {
+      t.error(err)
+      t.equal(buffers.length, 1)
+      t.equal(buffers[0].length, 3)
+    })
+  )
+})
+
+test('does not emit extra buffer if noEmpty and nopad is present', function (t) {
+  t.plan(4)
+
+  pull(
+    pull.values([
+      new Buffer([]),
+      new Buffer('hey'),
+      new Buffer([])
+    ]),
+    block({ emitEmpty: true }),
+    pull.collect(function (err, buffers) {
+      t.error(err)
+      t.equal(buffers.length, 1)
+      t.equal(buffers[0].length, 512)
+      t.deepEqual(buffers[0], Buffer.concat([new Buffer('hey'), Buffer.alloc(512 - 3)]))
+    })
+  )
+})

--- a/test/empty.js
+++ b/test/empty.js
@@ -107,7 +107,7 @@ test('does not emit extra buffer if noEmpty and nopad is present', function (t) 
   )
 })
 
-test('does not emit extra buffer if noEmpty and nopad is present', function (t) {
+test('does not emit extra buffer if noEmpty is present', function (t) {
   t.plan(4)
 
   pull(


### PR DESCRIPTION
When `option.emitEmpty` is true, if no buffering happened, always emit an empty buffer.

Includes tests and docs.