### PR TITLE
Perf: Use fewer slices in while loop

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,13 +30,15 @@ module.exports = function block (size, opts) {
     bufferedBytes += data.length
     buffered.push(data)
 
+    var b = Buffer.concat(buffered)
+    var offset = 0
     while (bufferedBytes >= size) {
-      var b = Buffer.concat(buffered)
+      this.queue(b.slice(offset, offset + size))
+      offset += size
       bufferedBytes -= size
-      this.queue(b.slice(0, size))
-      buffered = [ b.slice(size, b.length) ]
       emittedChunk = true
     }
+    buffered = [ b.slice(offset, b.length) ]
   }, function flush (end) {
     if ((opts.emitEmpty && !emittedChunk) || bufferedBytes) {
       if (zeroPadding) {


### PR DESCRIPTION
Should boost performance significantly for larger incoming buffers.
This fixes the issue for me at ipfs/js-ipfs-unixfs-engine#187

The way I implemented my test, a single buffer of 57621555 bytes comes in and gets split into ~220 blocks. By not slicing the remainder to a new buffer 219 times it saves a lot of buffer allocation churn to process a buffer as large as this.