### PR TITLE
Copy less data on flush

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,11 @@ module.exports = function block (size, opts) {
         buffered.push(zeroes)
       }
       if (buffered) {
-        this.queue(Buffer.concat(buffered).slice(bufferSkip))
+        if (buffered.length > 0) {
+          // Don't copy the bufferSkip bytes through concat.
+          buffered[0] = buffered[0].slice(bufferSkip)
+        }
+        this.queue(Buffer.concat(buffered))
         buffered = null
       }
     }


### PR DESCRIPTION
Based on #5 I realized the flush handling could also improve in the same way.

```js
bigRemainder: test({
	inSize: 200*MB,
	inCount: 1,
	blockSize: 101*MB
})
```

Test|Version|AVG
-|-|-
bigRemainder|pull-block dev #4|242ms
bigRemainder|pull-block dev #5|216ms
bigRemainder|pull-block dev #6|219ms
bigRemainder|pull-block dev|122ms
bigRemainder|pull-block master|240ms