### PR TITLE
Heuristic based squash of buffers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@
 var through = require('pull-through')
 var Buffer = require('safe-buffer').Buffer
 
+var SQUASH_BUFFER_THRESHOLD = 128
+
 function lazyConcat (buffers) {
   if (buffers.length === 1) return buffers[0]
   return Buffer.concat(buffers)
@@ -40,6 +42,13 @@ module.exports = function block (size, opts) {
       var targetLength = 0
       var target = []
       var b, end, out
+
+      if (buffered.length > SQUASH_BUFFER_THRESHOLD) {
+        buffered = [
+          Buffer.concat(buffered.slice(0, buffered.length - 1)),
+          buffered[buffered.length - 1]
+        ]
+      }
 
       while (targetLength < size) {
         b = buffered[0]


### PR DESCRIPTION
Fixes #9.

I've tried to come up with a "perfect" approach where the existing logic would be split up into:
- Dealing with the first buffer's skip
- Simplifying the middle buffers
- Dealing with the last buffer's remainder

But found that in benchmarks the required logic for that would slow down all other use-cases significantly. And added about 30 lines of code extra in complexity.

Similarly, lowering this threshold to it's minimum of 2 would cause the extra concat to slow down many use-cases as well, because the data is copied an extra time while a few iterations of the below loop could have handled it with great performance.

128 was chosen as an arbitrary factor for a use-case where input buffers are received that are disproportionately smaller than the requested blocks and would benefit from the simplicity of the additional concat over running the while loops.

Performance wise it has the best of both worlds. It is on par with 1.2.0 for single byte inputs or very small inputs and is on par with 1.2.1 for everything else.

Some Chrome perf highlights.

Test|Version|Min|AVG|Max
-|-|-:|-:|-:
nanoBufs2|dev|72ms|78ms|85ms
nanoBufs2|v1.2.1|190ms|198ms|365ms
nanoBufs2|v1.2.0|69ms|72ms|75ms
nanoBufs4|dev|73ms|75ms|77ms
nanoBufs4|v1.2.1|195ms|198ms|350ms
nanoBufs4|v1.2.0|70ms|72ms|73ms
nanoBufs16|dev|57ms|59ms|71ms
nanoBufs16|v1.2.1|134ms|137ms|228ms
nanoBufs16|v1.2.0|53ms|54ms|55ms
perByteSmall|dev|2ms|2ms|5ms
perByteSmall|v1.2.1|4ms|5ms|9ms
perByteSmall|v1.2.0|1ms|2ms|3ms
perByteMedium|dev|26ms|27ms|41ms
perByteMedium|v1.2.1|69ms|71ms|113ms
perByteMedium|v1.2.0|25ms|25ms|27ms
perByteLarge|dev|130ms|131ms|133ms
perByteLarge|v1.2.1|354ms|356ms|603ms
perByteLarge|v1.2.0|124ms|125ms|130ms
microPairs|dev|101ms|102ms|115ms
microPairs|v1.2.1|100ms|101ms|105ms
microPairs|v1.2.0|96ms|99ms|102ms
almostHalves|dev|19ms|24ms|27ms
almostHalves|v1.2.1|19ms|23ms|26ms
almostHalves|v1.2.0|194ms|199ms|205ms
almost10ths|dev|3ms|6ms|14ms
almost10ths|v1.2.1|4ms|4ms|5ms
almost10ths|v1.2.0|614ms|623ms|660ms
tinyBufs|dev|41ms|45ms|51ms
tinyBufs|v1.2.1|40ms|41ms|44ms
tinyBufs|v1.2.0|38ms|40ms|42ms
microBufs|dev|51ms|52ms|56ms
microBufs|v1.2.1|51ms|51ms|53ms
microBufs|v1.2.0|39ms|42ms|45ms
manyPairs|dev|57ms|58ms|60ms
manyPairs|v1.2.1|56ms|57ms|58ms
manyPairs|v1.2.0|69ms|70ms|72ms
perfectPairs|dev|37ms|38ms|45ms
perfectPairs|v1.2.1|37ms|38ms|39ms
perfectPairs|v1.2.0|38ms|38ms|39ms
manyTriplets|dev|41ms|43ms|59ms
manyTriplets|v1.2.1|42ms|43ms|44ms
manyTriplets|v1.2.0|45ms|46ms|48ms